### PR TITLE
Attempt to set HELPDIR automatically

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -5,9 +5,9 @@ bindkey '^[H' run-help
 
 if (( ! ${+HELPDIR} )); then
   local dir
-  for dir (/usr/local/share/zsh/help /usr/share/zsh/$ZSH_VERSION/help /usr/share/zsh/help); do
-    if [[ -d $dir ]]; then
-      typeset -g HELPDIR=$dir
+  for dir in /usr/local/share/zsh/help /usr/share/zsh/$ZSH_VERSION/help /usr/share/zsh/help; do
+    if [[ -d ${dir} ]]; then
+      typeset -g HELPDIR=${dir}
       break
     fi
   done

--- a/init.zsh
+++ b/init.zsh
@@ -3,6 +3,11 @@ autoload -Uz run-help
 bindkey '^[h' run-help
 bindkey '^[H' run-help
 
+if (( ! ${+HELPDIR} )); then
+  if [[ -d /usr/share/zsh/help ]] typeset -g HELPDIR=/usr/share/zsh/help
+  if [[ -d /usr/local/share/zsh/help ]] typeset -g HELPDIR=/usr/local/share/zsh/help
+fi
+
 local cmd
 for cmd in git ip openssl p4 sudo svk svn; do
   if (( ${+commands[${cmd}]} )) autoload -Uz run-help-${cmd}

--- a/init.zsh
+++ b/init.zsh
@@ -4,8 +4,14 @@ bindkey '^[h' run-help
 bindkey '^[H' run-help
 
 if (( ! ${+HELPDIR} )); then
-  if [[ -d /usr/share/zsh/help ]] typeset -g HELPDIR=/usr/share/zsh/help
-  if [[ -d /usr/local/share/zsh/help ]] typeset -g HELPDIR=/usr/local/share/zsh/help
+  local dir
+  for dir (/usr/local/share/zsh/help /usr/share/zsh/$ZSH_VERSION/help /usr/share/zsh/help); do
+    if [[ -d $dir ]]; then
+      typeset -g HELPDIR=$dir
+      break
+    fi
+  done
+  unset dir
 fi
 
 local cmd

--- a/init.zsh
+++ b/init.zsh
@@ -1,8 +1,3 @@
-unalias run-help 2>/dev/null
-autoload -Uz run-help
-bindkey '^[h' run-help
-bindkey '^[H' run-help
-
 if (( ! ${+HELPDIR} )); then
   local dir
   for dir in /usr/local/share/zsh/help /usr/share/zsh/$ZSH_VERSION/help /usr/share/zsh/help; do
@@ -13,6 +8,11 @@ if (( ! ${+HELPDIR} )); then
   done
   unset dir
 fi
+
+unalias run-help 2>/dev/null
+autoload -Uz run-help
+bindkey '^[h' run-help
+bindkey '^[H' run-help
 
 local cmd
 for cmd in git ip openssl p4 sudo svk svn; do

--- a/init.zsh
+++ b/init.zsh
@@ -1,6 +1,6 @@
 if (( ! ${+HELPDIR} )); then
   local dir
-  for dir in /usr/local/share/zsh/help /usr/share/zsh/$ZSH_VERSION/help /usr/share/zsh/help; do
+  for dir in /usr/local/share/zsh/help /usr/share/zsh/${ZSH_VERSION}/help /usr/share/zsh/help; do
     if [[ -d ${dir} ]]; then
       typeset -g HELPDIR=${dir}
       break


### PR DESCRIPTION
The help provided by the `run-help` function can be significantly more helpful if you've first set the `HELPDIR` parameter appropriately - in particular, asking for help about a Zsh builtin will display *only* the relevant help for that builtin, rather than opening all of `man zshbuiltins`. Unfortunately there's no 100% reliable way to set this parameter, since the help dir's location depends on how Zsh was installed and can even be [under your home directory if you built your own Zsh](https://zsh.sourceforge.io/Doc/Release/User-Contributions.html#Accessing-On_002dLine-Help).

I've set up a heuristic approach: we check the two most common locations for the Zsh helpdir, silently failing if neither exist. If both /usr/share help and /usr/local/share help exist, we intentionally allow the latter to override the former, since it is likely to be newer. Additionally, if the user or their distribution has already set `HELPDIR` to something, even an empty string, we won't try to change it. This approach should be least obtrusive for existing users of the zimfw/run-help module.

- [x] I've followed Zim's [code style guidelines](https://github.com/zimfw/zimfw/wiki/Code-Style-Guide).
